### PR TITLE
Linear solvers names have been updated to new standard

### DIFF
--- a/poromechanics/use_cases/consolidation_interface_3D/source/ProjectParameters.json
+++ b/poromechanics/use_cases/consolidation_interface_3D/source/ProjectParameters.json
@@ -47,7 +47,7 @@
         "nonlocal_damage":                    false,
         "characteristic_length":              0.05,
         "linear_solver_settings":             {
-            "solver_type":     "AMGCL",
+            "solver_type":     "amgcl",
             "smoother_type":   "ilu0",
             "krylov_type":     "gmres",
             "coarsening_type": "aggregation",

--- a/poromechanics/use_cases/consolidation_interface_3D/source/consolidation_interface_3D.prb
+++ b/poromechanics/use_cases/consolidation_interface_3D/source/consolidation_interface_3D.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: true
-QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,ExternalSolversApplication.super_lu,bicgstab,amgcl,klu,aztec,amgcl,multi_level)
 VALUE: amgcl
-HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), ExternalSolversApplication.super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: klu,aztec,amgcl,multi_level.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/use_cases/consolidation_interface_3D/source/consolidation_interface_3D.prb
+++ b/poromechanics/use_cases/consolidation_interface_3D/source/consolidation_interface_3D.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: true
-QUESTION: Solver_Type#CB#(SkylineLUFactorizationSolver,SuperLUSolver,BICGSTABSolver,AMGCL,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
-VALUE: AMGCL
-HELP: OpenMP solvers: SkylineLUFactorizationSolver (Direct), SuperLUSolver (Direct), BICGSTABSolver (Iter.) and AMGCL (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+VALUE: amgcl
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/use_cases/fluid_pumping_2D/source/ProjectParameters.json
+++ b/poromechanics/use_cases/fluid_pumping_2D/source/ProjectParameters.json
@@ -47,7 +47,7 @@
         "nonlocal_damage":                    false,
         "characteristic_length":              0.05,
         "linear_solver_settings":             {
-            "solver_type":     "AMGCL",
+            "solver_type":     "amgcl",
             "smoother_type":   "ilu0",
             "krylov_type":     "gmres",
             "coarsening_type": "aggregation",

--- a/poromechanics/use_cases/fluid_pumping_2D/source/fluid_pumping_2D.prb
+++ b/poromechanics/use_cases/fluid_pumping_2D/source/fluid_pumping_2D.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: true
-QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,ExternalSolversApplication.super_lu,bicgstab,amgcl,klu,aztec,amgcl,multi_level)
 VALUE: amgcl
-HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), ExternalSolversApplication.super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: klu,aztec,amgcl,multi_level.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/use_cases/fluid_pumping_2D/source/fluid_pumping_2D.prb
+++ b/poromechanics/use_cases/fluid_pumping_2D/source/fluid_pumping_2D.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: true
-QUESTION: Solver_Type#CB#(SkylineLUFactorizationSolver,SuperLUSolver,BICGSTABSolver,AMGCL,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
-VALUE: AMGCL
-HELP: OpenMP solvers: SkylineLUFactorizationSolver (Direct), SuperLUSolver (Direct), BICGSTABSolver (Iter.) and AMGCL (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+VALUE: amgcl
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/use_cases/fluid_pumping_2D_fracture/source/ProjectParameters.json
+++ b/poromechanics/use_cases/fluid_pumping_2D_fracture/source/ProjectParameters.json
@@ -47,11 +47,11 @@
         "nonlocal_damage":                    true,
         "characteristic_length":              0.1,
         "linear_solver_settings":             {
-            "solver_type":         "BICGSTABSolver",
+            "solver_type":         "bicgstab",
             "tolerance":           1.0e-6,
             "max_iteration":       100,
             "scaling":             false,
-            "preconditioner_type": "ILU0Preconditioner"
+            "preconditioner_type": "ilu0"
         },
         "problem_domain_sub_model_part_list": ["Body_Part-auto-1","Interface_Part-auto-1"],
         "processes_sub_model_part_list":      ["Solid_Displacement-auto-2","Fluid_Pressure-auto-1","Normal_Fluid_Flux-auto-1","Interface_Normal_Fluid_Flux-auto-1"],

--- a/poromechanics/use_cases/fluid_pumping_2D_fracture/source/fluid_pumping_2D_fracture.prb
+++ b/poromechanics/use_cases/fluid_pumping_2D_fracture/source/fluid_pumping_2D_fracture.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: false
-QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,ExternalSolversApplication.super_lu,bicgstab,amgcl,klu,aztec,amgcl,multi_level)
 VALUE: bicgstab
-HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), ExternalSolversApplication.super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: klu,aztec,amgcl,multi_level.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/use_cases/fluid_pumping_2D_fracture/source/fluid_pumping_2D_fracture.prb
+++ b/poromechanics/use_cases/fluid_pumping_2D_fracture/source/fluid_pumping_2D_fracture.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: false
-QUESTION: Solver_Type#CB#(SkylineLUFactorizationSolver,SuperLUSolver,BICGSTABSolver,AMGCL,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
-VALUE: BICGSTABSolver
-HELP: OpenMP solvers: SkylineLUFactorizationSolver (Direct), SuperLUSolver (Direct), BICGSTABSolver (Iter.) and AMGCL (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+VALUE: bicgstab
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/validation/arc_length_test/source/ProjectParameters.json
+++ b/poromechanics/validation/arc_length_test/source/ProjectParameters.json
@@ -47,11 +47,11 @@
         "nonlocal_damage":                    true,
         "characteristic_length":              0.01,
         "linear_solver_settings":             {
-            "solver_type":         "BICGSTABSolver",
+            "solver_type":         "bicgstab",
             "tolerance":           1.0e-6,
             "max_iteration":       100,
             "scaling":             false,
-            "preconditioner_type": "ILU0Preconditioner"
+            "preconditioner_type": "ilu0"
         },
         "problem_domain_sub_model_part_list": ["Body_Part-auto-1"],
         "processes_sub_model_part_list":      ["Solid_Displacement-auto-1","Solid_Displacement-auto-2","Fluid_Pressure-auto-1","Face_Load-auto-1","Face_Load-auto-2"],

--- a/poromechanics/validation/arc_length_test/source/arc_length_test.prb
+++ b/poromechanics/validation/arc_length_test/source/arc_length_test.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: false
-QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,ExternalSolversApplication.super_lu,bicgstab,amgcl,klu,aztec,amgcl,multi_level)
 VALUE: bicgstab
-HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), ExternalSolversApplication.super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: klu,aztec,amgcl,multi_level.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/validation/arc_length_test/source/arc_length_test.prb
+++ b/poromechanics/validation/arc_length_test/source/arc_length_test.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: false
-QUESTION: Solver_Type#CB#(SkylineLUFactorizationSolver,SuperLUSolver,BICGSTABSolver,AMGCL,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
-VALUE: BICGSTABSolver
-HELP: OpenMP solvers: SkylineLUFactorizationSolver (Direct), SuperLUSolver (Direct), BICGSTABSolver (Iter.) and AMGCL (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+VALUE: bicgstab
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/validation/undrained_soil_column_2D/source/ProjectParameters.json
+++ b/poromechanics/validation/undrained_soil_column_2D/source/ProjectParameters.json
@@ -47,7 +47,7 @@
         "nonlocal_damage":                    false,
         "characteristic_length":              0.05,
         "linear_solver_settings":             {
-            "solver_type":   "SuperLUSolver"
+            "solver_type":   "super_lu"
         },
         "problem_domain_sub_model_part_list": ["Body_Part-auto-1"],
         "processes_sub_model_part_list":      ["Solid_Displacement-auto-1","Solid_Displacement-auto-2","Solid_Displacement-auto-3","Fluid_Pressure-auto-1","Face_Load-auto-1","Normal_Fluid_Flux-auto-1"],

--- a/poromechanics/validation/undrained_soil_column_2D/source/ProjectParameters.json
+++ b/poromechanics/validation/undrained_soil_column_2D/source/ProjectParameters.json
@@ -47,7 +47,7 @@
         "nonlocal_damage":                    false,
         "characteristic_length":              0.05,
         "linear_solver_settings":             {
-            "solver_type":   "super_lu"
+            "solver_type":   "ExternalSolversApplication.super_lu"
         },
         "problem_domain_sub_model_part_list": ["Body_Part-auto-1"],
         "processes_sub_model_part_list":      ["Solid_Displacement-auto-1","Solid_Displacement-auto-2","Solid_Displacement-auto-3","Fluid_Pressure-auto-1","Face_Load-auto-1","Normal_Fluid_Flux-auto-1"],

--- a/poromechanics/validation/undrained_soil_column_2D/source/undrained_soil_column_2D.prb
+++ b/poromechanics/validation/undrained_soil_column_2D/source/undrained_soil_column_2D.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: false
-QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
-VALUE: super_lu
-HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,ExternalSolversApplication.super_lu,bicgstab,amgcl,klu,aztec,amgcl,multi_level)
+VALUE: ExternalSolversApplication.super_lu
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), ExternalSolversApplication.super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: klu,aztec,amgcl,multi_level.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity

--- a/poromechanics/validation/undrained_soil_column_2D/source/undrained_soil_column_2D.prb
+++ b/poromechanics/validation/undrained_soil_column_2D/source/undrained_soil_column_2D.prb
@@ -100,9 +100,9 @@ QUESTION: Move_Mesh#CB#(true,false)
 VALUE: false
 QUESTION: Block_Builder#CB#(true,false)
 VALUE: false
-QUESTION: Solver_Type#CB#(SkylineLUFactorizationSolver,SuperLUSolver,BICGSTABSolver,AMGCL,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
-VALUE: SuperLUSolver
-HELP: OpenMP solvers: SkylineLUFactorizationSolver (Direct), SuperLUSolver (Direct), BICGSTABSolver (Iter.) and AMGCL (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
+QUESTION: Solver_Type#CB#(skyline_lu_factorization,super_lu,bicgstab,amgcl,Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver)
+VALUE: super_lu
+HELP: OpenMP solvers: skyline_lu_factorization (Direct), super_lu (Direct), bicgstab (Iter.) and amgcl (Iter.). MPI solvers: Klu,AztecSolver,AmgclMPISolver,MultiLevelSolver.
 QUESTION: Scaling#CB#(true,false)
 VALUE: false
 QUESTION: Verbosity


### PR DESCRIPTION
The linear solvers names of the Examples have been also updated according to the current nomenclature of python_linear_solver_factory (following Kratos PR #4063).

Still with the same doubt of using "super_lu" or "ExternalSolversApplication.super_lu" ...