### PR TITLE
Fix incomplete list of required apps for the dam break example.

### DIFF
--- a/co_simulation/validation/dam_break_flex_wall/README.md
+++ b/co_simulation/validation/dam_break_flex_wall/README.md
@@ -16,6 +16,7 @@ This is a 2D FSI simulation of the dam break against a flexible wall benchmark t
 * MappingApplication
 * MeshingApplication
 * LinearSolversApplication
+* KratosDelaunayMeshingApplication
 
 The problem geometry as well as the boundary conditions are sketched below.
 <p align="center">


### PR DESCRIPTION
The PfemFluidDynamicsApplication directly depends on the KratosDelaunayMeshingApplication, but the latter was not listed as a required app.